### PR TITLE
feat: BlockLinkInfoCard

### DIFF
--- a/app/src/main/kotlin/re/limus/timas/hook/items/message/BlockLinkInfoCard.kt
+++ b/app/src/main/kotlin/re/limus/timas/hook/items/message/BlockLinkInfoCard.kt
@@ -8,16 +8,18 @@ import re.limus.timas.hook.base.SwitchHook
 // dartcv
 @RegisterToUI
 object BlockLinkInfoCard: SwitchHook() {
-    override val name: String
-        get() = "屏蔽链接信息卡片"
+    
+    override val name = "屏蔽链接信息卡片"
+    
     override val category = UiCategory.MESSAGE
 
     override fun onHook(ctx: Context, loader: ClassLoader) {
-        loader.loadClass("com.tencent.qqnt.kernel.nativeinterface.LinkInfo").declaredConstructors.forEach { constructor ->
-            constructor.hookBefore {
-                if(args[0]!=null) result = null
+        DexFinder.findMethod {
+            declaredClass = "com.tencent.qqnt.kernel.nativeinterface.LinkInfo".toClass()
+        }.hookConstructorBefore {
+            if (args[0] != null) { 
+                result = null
             }
         }
     }
-
 }


### PR DESCRIPTION
新增功能：屏蔽链接信息卡片
用途：阻止异常协议消息偷流量/净化TIM
以及：打死Hd